### PR TITLE
Fix dev ts-node usage and enable data access

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/src/server.js",
-    "dev": "ts-node-dev src/server.ts"
+    "dev": "ts-node src/server.ts"
   },
   "keywords": [],
   "author": "",

--- a/apps/frontend/src/pages/ChooseSchool.tsx
+++ b/apps/frontend/src/pages/ChooseSchool.tsx
@@ -130,20 +130,7 @@ const ChooseSchool = () => {
     setNavbarButtons([...baseButtons, menuToggleButton]);
     setNavbarTitle(undefined);
 
-    showModal({
-      title: "此功能尚未開放，敬請期待！",
-      description: ":D",
-      buttons: [
-        {
-          label: "回主頁",
-          role: "primary",
-          style: "btn-primary",
-          onClick: () => navigate("/intro"),
-        },
-      ],
-    });
-
-    // a();
+    a();
   }, []);
 
   return (


### PR DESCRIPTION
Correct the usage of `ts-node` in the development script and remove the modal that previously indicated a feature was not available, allowing direct access to data.